### PR TITLE
Allow frontend to be served as static content

### DIFF
--- a/tuichain/settings.py
+++ b/tuichain/settings.py
@@ -84,7 +84,11 @@ ROOT_URLCONF = 'tuichain.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': (
+            []
+            if 'REDIRECT_URL' in os.environ
+            else [os.environ['FRONTEND_BUILD_DIR']]
+            ),
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -159,7 +163,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'static'),
+    os.path.join(os.environ.get('FRONTEND_BUILD_DIR', BASE_DIR), 'static'),
 )
 
 

--- a/tuichain/urls.py
+++ b/tuichain/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.conf.urls import url
 from django.urls import path, include
+from django.shortcuts import render
 from django.views.generic import RedirectView
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework import routers
@@ -26,8 +27,14 @@ schema_view = get_schema_view(
 
 router = routers.DefaultRouter()
 
+index = (
+    RedirectView.as_view(url=os.environ['REDIRECT_URL'])
+    if 'REDIRECT_URL' in os.environ
+    else lambda request: render(request, "index.html")
+    )
+
 urlpatterns = [
-    path('', RedirectView.as_view(url=os.environ['REDIRECT_URL'])),
+    path('', index),
     path('api/', include(router.urls)),
     # AUTHENTICATION ROUTES
     path('api/auth/login/', auth.login),


### PR DESCRIPTION
This doesn't change existing behavior, but allows the frontend to be served as static content by setting the FRONTEND_BUILD_DIR environment variable to the React build path.

This is likely more of a hack than a proper solution, but implements the final missing piece for the local deployment scripts to work.