### PR TITLE
Remove unused dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ coreapi==2.3.3
 coreschema==0.0.4
 dj-database-url==0.5.0
 django-cors-headers==3.5.0
-django-heroku==0.3.1
 Django==3.1.2
 djangorestframework==3.12.1
 drf-yasg==1.20.0
@@ -41,5 +40,4 @@ toml==0.10.1
 typed-ast==1.4.1
 uritemplate==3.0.1
 urllib3==1.26.2
-whitenoise==5.2.0
 wrapt==1.12.1


### PR DESCRIPTION
django-heroku was also causing a transitive dependency on psycopg2, which required PostgreSQL to be installed.