### PR TITLE
Don't serve static content

### DIFF
--- a/.env_test
+++ b/.env_test
@@ -2,8 +2,6 @@ SECRET_KEY=test
 DEBUG=True
 ALLOWED_HOSTS=
 
-FRONTEND_DIR=
-
 DATABASE_ENGINE=django.db.backends.sqlite3
 DATABASE_NAME=:memory:
 DATABASE_USER=

--- a/tuichain/settings.py
+++ b/tuichain/settings.py
@@ -56,9 +56,6 @@ INSTALLED_APPS = [
     "corsheaders",
 ]
 
-if environ["FRONTEND_DIR"]:
-    INSTALLED_APPS.append("django.contrib.staticfiles")
-
 MIDDLEWARE = [
     # CORS
     "corsheaders.middleware.CorsMiddleware",
@@ -91,25 +88,6 @@ TEMPLATES = [
         },
     },
 ]
-
-# ---------------------------------------------------------------------------- #
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/3.1/howto/static-files/
-
-if environ["FRONTEND_DIR"]:
-
-    FRONTEND_DIR = Path(environ["FRONTEND_DIR"])
-
-    STATIC_URL = "/static/"
-    STATICFILES_DIRS = [FRONTEND_DIR / "static"]
-    STATICFILES_STORAGE = None
-    STATICFILES_FINDERS = [
-        "django.contrib.staticfiles.finders.FileSystemFinder"
-    ]
-
-else:
-
-    FRONTEND_DIR = None
 
 # ---------------------------------------------------------------------------- #
 # Database

--- a/tuichain/urls.py
+++ b/tuichain/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib import admin
-from django.views.static import serve
 from django.urls import include, path, re_path
 from django.views.generic import RedirectView
 from rest_framework.authtoken.views import obtain_auth_token
@@ -106,21 +105,3 @@ urlpatterns = [
     #        name="schema-redoc",
     #    ),
 ]
-
-if settings.FRONTEND_DIR is not None:
-
-    urlpatterns += [
-        re_path(
-            r"^(?P<path>[^/]+\.[^/]+)$",
-            serve,
-            kwargs={"document_root": settings.FRONTEND_DIR},
-        ),
-        re_path(
-            r"^(?!api/|swagger/)",
-            serve,
-            kwargs={
-                "path": "index.html",
-                "document_root": settings.FRONTEND_DIR,
-            },
-        ),
-    ]


### PR DESCRIPTION
This is no longer needed by the development deployment scripts, and will never be used in production.